### PR TITLE
More granular Gradle cache paths

### DIFF
--- a/step/step.go
+++ b/step/step.go
@@ -26,8 +26,20 @@ const (
 
 // Cached paths
 var paths = []string{
-	// Local Gradle cache folder (contains build cache too when `org.gradle.caching = true`)
-	"~/.gradle/caches",
+
+	// Dependency JARs
+	"~/.gradle/caches/jars-*",
+
+	// Dependency AARs
+	"~/.gradle/caches/modules-*/files-*",
+
+	// Generated JARs for plugins and build scripts
+	// The `**` segment matches the version-specific folder, such as `7.6`.
+	"~/.gradle/caches/**/generated-gradle-jars/*.jar",
+
+	// Kotlin build script cache
+	// The `**` segment matches the version-specific folder, such as `7.6`.
+	"~/.gradle/caches/**/kotlin-dsl",
 
 	// Cache of downloaded Gradle binary
 	"~/.gradle/wrapper",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

The build cache (located at `~/.gradle/caches/build-cache-1`) is included in the cache right now if the project enables build caching. This happens because we include the entire `.gradle/caches` folder.

### Changes

Add more granular rules for caching subfolders of the `.gradle/caches` folder based on https://docs.gradle.org/current/userguide/directory_layout.html#dir:gradle_user_home

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
