### PR TITLE
Add Gradle build cache folder

### DIFF
--- a/step/step.go
+++ b/step/step.go
@@ -49,6 +49,9 @@ var paths = []string{
 
 	// JDKs downloaded by the toolchain support
 	"~/.gradle/jdks",
+
+	// Build cache
+	"~/.gradle/caches/build-cache-*",
 }
 
 type Input struct {


### PR DESCRIPTION

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Context

Current cache step ignores the build cache. Opening issues here is only for bug reports so I tried to open the discussion with a Pull Request.

Switching from a custom cache step where we had build cache store to this one, increased build time by a factor of ~5.

Was excluding build cache a conscious decision? If so would you consider input booleans to configure it?

### Changes

Gradle stores build cache it the `~/.gradle/caches/build-cache-*`
Adds the folder in the list.
