### PR TITLE
Add wildcards to gradle.properties and libs.versions.toml checksum paths

### DIFF
--- a/step/step.go
+++ b/step/step.go
@@ -19,9 +19,9 @@ const (
 	// checksum values:
 	// - `**/*.gradle*`: Gradle build files in any submodule, including ones written in Kotlin (*.gradle.kts)
 	// - `**/gradle-wrapper.properties`: contains exact Gradle version
-	// - `gradle.properties`: contains Gradle config values
-	// - `gradle/libs.versions.toml`: version catalog file, contains dependencies and their versions
-	key = `{{ .OS }}-{{ .Arch }}-gradle-cache-{{ checksum "**/*.gradle*" "**/gradle-wrapper.properties" "gradle.properties" "gradle/libs.versions.toml" }}`
+	// - `**/gradle.properties`: contains Gradle config values
+	// - `**/gradle/libs.versions.toml`: version catalog file, contains dependencies and their versions
+	key = `{{ .OS }}-{{ .Arch }}-gradle-cache-{{ checksum "**/*.gradle*" "**/gradle-wrapper.properties" "**/gradle.properties" "**/gradle/libs.versions.toml" }}`
 )
 
 // Cached paths


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

If a gradle project contains submodules with their own `gradle.properties` and `gradle/libs.versions.toml` files they wouldn't be taken into account for checksum calculation.

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

Add wildcards to include all `gradle.properties` and `gradle/libs.versions.toml` files.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
