### PR TITLE
Include `~/.gradle/caches/modules-*/metadata-*` paths

### DIFF
--- a/step/step.go
+++ b/step/step.go
@@ -32,6 +32,7 @@ var paths = []string{
 
 	// Dependency AARs
 	"~/.gradle/caches/modules-*/files-*",
+	"~/.gradle/caches/modules-*/metadata",
 
 	// Generated JARs for plugins and build scripts
 	// The `**` segment matches the version-specific folder, such as `7.6`.

--- a/step/step.go
+++ b/step/step.go
@@ -32,7 +32,7 @@ var paths = []string{
 
 	// Dependency AARs
 	"~/.gradle/caches/modules-*/files-*",
-	"~/.gradle/caches/modules-*/metadata",
+	"~/.gradle/caches/modules-*/metadata-*",
 
 	// Generated JARs for plugins and build scripts
 	// The `**` segment matches the version-specific folder, such as `7.6`.


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

We've recently migrated away from branch-based caching and onto key-based caching for our Android project and while we've had great results already, I had seen that something was missing still in the way that Gradle dependencies were being cached.

The result was that we saved over 2 minutes in cache retrieval/saving time so I was pretty happy with everything. That was until our nightly builds failed last night due to an issue resolving dependencies from Maven which led me to do some more digging as this was something that we hadn't seen before (so either it was bad timing or something changed regarding caching of dependencies).

### Changes

Add `"~/.gradle/caches/modules-*/metadata-*"` to the paths being cached.

### Investigation details

I pulled down our old branch-based cache and compared the `~/.gradle/caches` directory against what is being pushed to the key-based cache. The directory of interest to me is the `modules` directory, because if my research is correct, this is where [_Shared caches (e.g. for artifacts of dependencies)_](https://docs.gradle.org/current/userguide/directory_layout.html) are stored:

Branch|Key
---|---
<img width="797" alt="Branch" src="https://user-images.githubusercontent.com/482871/233320636-64accae0-ad57-4c9b-b68b-655432e9e6de.png">|<img width="797" alt="Key" src="https://user-images.githubusercontent.com/482871/233320647-d2af5e02-6e96-4067-a567-5e24541b3aed.png">

While we're currently caching the `files-*` directory, we seem to not be caching the nested `metadata-*` directory. Was this intentional? I'm not sure. However when I did some testing locally, if I run `./gradlew dependencies` without that directory and with WiFi off, the command fails:

<details>
<summary><code>$ ./gradlew dependencies</code> (no metadata or WiFi)</summary>

```
$ time ./gradlew dependencies

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':buildSrc'.
> Could not resolve all files for configuration ':buildSrc:classpath'.
   > Did not resolve 'org.jetbrains.kotlin:kotlin-android-extensions:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-gradle-plugin-idea:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-serialization:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-build-common:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-gradle-plugin-model:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-util-io:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-project-model:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.5.0' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-tooling-core:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-daemon-embeddable:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-native-utils:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-annotation-processing-gradle:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-util-klib:1.7.21' which is part of the dependency lock state
   > Did not resolve 'net.java.dev.jna:jna:5.6.0' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-daemon-client:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-compiler-runner:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-gradle-plugin-idea-proto:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-scripting-jvm:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-gradle-plugin-api:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-scripting-common:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.kotlin:kotlin-klib-commonizer-api:1.7.21' which is part of the dependency lock state
   > Did not resolve 'org.jetbrains.intellij.deps:trove4j:1.0.20200330' which is part of the dependency lock state
   > Could not resolve org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21.
     Required by:
         project :buildSrc
      > Could not resolve org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21.
         > Could not get resource 'https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin/1.7.21/kotlin-gradle-plugin-1.7.21.pom'.
            > Could not HEAD 'https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin/1.7.21/kotlin-gradle-plugin-1.7.21.pom'.
               > repo.maven.apache.org
      > Could not resolve org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21.
         > Could not get resource 'https://jitpack.io/org/jetbrains/kotlin/kotlin-gradle-plugin/1.7.21/kotlin-gradle-plugin-1.7.21.pom'.
            > Could not HEAD 'https://jitpack.io/org/jetbrains/kotlin/kotlin-gradle-plugin/1.7.21/kotlin-gradle-plugin-1.7.21.pom'.
               > jitpack.io
      > Could not resolve org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21.
         > Could not get resource 'https://dl.google.com/dl/android/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin/1.7.21/kotlin-gradle-plugin-1.7.21.pom'.
            > Could not HEAD 'https://dl.google.com/dl/android/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin/1.7.21/kotlin-gradle-plugin-1.7.21.pom'.
               > dl.google.com
   > Could not resolve org.jetbrains.kotlin:kotlin-serialization:1.7.21.
     Required by:
         project :buildSrc
      > Could not resolve org.jetbrains.kotlin:kotlin-serialization:1.7.21.
         > Could not get resource 'https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-serialization/1.7.21/kotlin-serialization-1.7.21.pom'.
            > Could not HEAD 'https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-serialization/1.7.21/kotlin-serialization-1.7.21.pom'.
               > repo.maven.apache.org
      > Could not resolve org.jetbrains.kotlin:kotlin-serialization:1.7.21.
         > Could not get resource 'https://jitpack.io/org/jetbrains/kotlin/kotlin-serialization/1.7.21/kotlin-serialization-1.7.21.pom'.
            > Could not HEAD 'https://jitpack.io/org/jetbrains/kotlin/kotlin-serialization/1.7.21/kotlin-serialization-1.7.21.pom'.
               > jitpack.io
      > Could not resolve org.jetbrains.kotlin:kotlin-serialization:1.7.21.
         > Could not get resource 'https://dl.google.com/dl/android/maven2/org/jetbrains/kotlin/kotlin-serialization/1.7.21/kotlin-serialization-1.7.21.pom'.
            > Could not HEAD 'https://dl.google.com/dl/android/maven2/org/jetbrains/kotlin/kotlin-serialization/1.7.21/kotlin-serialization-1.7.21.pom'.
               > dl.google.com
   > Could not resolve org.jetbrains.kotlin:kotlin-serialization:1.7.21.
     Required by:
         project :buildSrc
      > Could not resolve org.jetbrains.kotlin:kotlin-serialization:1.7.21.
         > Could not get resource 'https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-serialization/1.7.21/kotlin-serialization-1.7.21.pom'.
            > Could not HEAD 'https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-serialization/1.7.21/kotlin-serialization-1.7.21.pom'.
               > repo.maven.apache.org
      > Could not resolve org.jetbrains.kotlin:kotlin-serialization:1.7.21.
         > Could not get resource 'https://jitpack.io/org/jetbrains/kotlin/kotlin-serialization/1.7.21/kotlin-serialization-1.7.21.pom'.
            > Could not HEAD 'https://jitpack.io/org/jetbrains/kotlin/kotlin-serialization/1.7.21/kotlin-serialization-1.7.21.pom'.
               > jitpack.io
      > Could not resolve org.jetbrains.kotlin:kotlin-serialization:1.7.21.
         > Could not get resource 'https://dl.google.com/dl/android/maven2/org/jetbrains/kotlin/kotlin-serialization/1.7.21/kotlin-serialization-1.7.21.pom'.
            > Could not HEAD 'https://dl.google.com/dl/android/maven2/org/jetbrains/kotlin/kotlin-serialization/1.7.21/kotlin-serialization-1.7.21.pom'.
               > dl.google.com
   > Could not resolve org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21.
     Required by:
         project :buildSrc
      > Could not resolve org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21.
         > Could not get resource 'https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin/1.7.21/kotlin-gradle-plugin-1.7.21.pom'.
            > Could not HEAD 'https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin/1.7.21/kotlin-gradle-plugin-1.7.21.pom'.
               > repo.maven.apache.org
      > Could not resolve org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21.
         > Could not get resource 'https://jitpack.io/org/jetbrains/kotlin/kotlin-gradle-plugin/1.7.21/kotlin-gradle-plugin-1.7.21.pom'.
            > Could not HEAD 'https://jitpack.io/org/jetbrains/kotlin/kotlin-gradle-plugin/1.7.21/kotlin-gradle-plugin-1.7.21.pom'.
               > jitpack.io
      > Could not resolve org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21.
         > Could not get resource 'https://dl.google.com/dl/android/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin/1.7.21/kotlin-gradle-plugin-1.7.21.pom'.
            > Could not HEAD 'https://dl.google.com/dl/android/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin/1.7.21/kotlin-gradle-plugin-1.7.21.pom'.
               > dl.google.com

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 561ms
./gradlew dependencies  0.79s user 0.08s system 76% cpu 1.151 total
```

</details>

However, after running the command successfully with an internet connection to build the metadata, I am then able to run the command successfully without an internet connection:

<details>
<summary><code>$ ./gradlew dependencies</code> (with metadata, no wifi)</summary>

```
$ time ./gradlew dependencies

> Task :dependencies

------------------------------------------------------------
Root project 'global-android'
------------------------------------------------------------

detekt - The detekt dependencies to be used for this project.
\--- io.gitlab.arturbosch.detekt:detekt-cli:1.21.0-RC1
     +--- com.beust:jcommander:1.82
     +--- io.gitlab.arturbosch.detekt:detekt-tooling:1.21.0-RC1
     |    \--- io.gitlab.arturbosch.detekt:detekt-api:1.21.0-RC1
     |         +--- io.gitlab.arturbosch.detekt:detekt-utils:1.21.0-RC1
     |         +--- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.6.21
     |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.6.21
     |         |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21
     |         |    |    \--- org.jetbrains:annotations:13.0
     |         |    +--- org.jetbrains.kotlin:kotlin-script-runtime:1.6.21
     |         |    +--- org.jetbrains.kotlin:kotlin-reflect:1.6.21
     |         |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.6.21 (*)
     |         |    +--- org.jetbrains.kotlin:kotlin-daemon-embeddable:1.6.21
     |         |    +--- org.jetbrains.intellij.deps:trove4j:1.0.20200330
     |         |    \--- net.java.dev.jna:jna:5.6.0
     |         \--- io.gitlab.arturbosch.detekt:detekt-psi-utils:1.21.0-RC1
     |              \--- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.6.21 (*)
     +--- io.gitlab.arturbosch.detekt:detekt-parser:1.21.0-RC1
     |    +--- io.gitlab.arturbosch.detekt:detekt-psi-utils:1.21.0-RC1 (*)
     |    +--- io.github.davidburstrom.contester:contester-breakpoint:0.2.0
     |    \--- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.6.21 (*)
     +--- io.gitlab.arturbosch.detekt:detekt-core:1.21.0-RC1
     |    +--- org.yaml:snakeyaml:1.30
     |    +--- io.gitlab.arturbosch.detekt:detekt-metrics:1.21.0-RC1
     |    |    \--- io.gitlab.arturbosch.detekt:detekt-api:1.21.0-RC1 (*)
     |    +--- io.gitlab.arturbosch.detekt:detekt-psi-utils:1.21.0-RC1 (*)
     |    +--- io.gitlab.arturbosch.detekt:detekt-report-html:1.21.0-RC1
     |    |    +--- io.gitlab.arturbosch.detekt:detekt-utils:1.21.0-RC1
     |    |    \--- org.jetbrains.kotlinx:kotlinx-html-jvm:0.7.5
     |    +--- io.gitlab.arturbosch.detekt:detekt-report-txt:1.21.0-RC1
     |    +--- io.gitlab.arturbosch.detekt:detekt-report-xml:1.21.0-RC1
     |    +--- io.gitlab.arturbosch.detekt:detekt-report-sarif:1.21.0-RC1
     |    |    \--- io.github.detekt.sarif4k:sarif4k:0.0.1
     |    |         +--- org.jetbrains.kotlinx:kotlinx-serialization-json:1.1.0
     |    |         |    \--- org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.1.0
     |    |         |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.30 -> 1.6.21 (*)
     |    |         |         +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.30 -> 1.6.21
     |    |         |         \--- org.jetbrains.kotlinx:kotlinx-serialization-core:1.1.0
     |    |         |              \--- org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.1.0
     |    |         |                   +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.30 -> 1.6.21 (*)
     |    |         |                   \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.30 -> 1.6.21
     |    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.31 -> 1.6.21 (*)
     |    +--- io.gitlab.arturbosch.detekt:detekt-utils:1.21.0-RC1
     |    +--- io.gitlab.arturbosch.detekt:detekt-api:1.21.0-RC1 (*)
     |    +--- io.gitlab.arturbosch.detekt:detekt-parser:1.21.0-RC1 (*)
     |    \--- io.gitlab.arturbosch.detekt:detekt-tooling:1.21.0-RC1 (*)
     \--- io.gitlab.arturbosch.detekt:detekt-rules:1.21.0-RC1
          +--- io.gitlab.arturbosch.detekt:detekt-rules-complexity:1.21.0-RC1
          +--- io.gitlab.arturbosch.detekt:detekt-rules-coroutines:1.21.0-RC1
          +--- io.gitlab.arturbosch.detekt:detekt-rules-documentation:1.21.0-RC1
          +--- io.gitlab.arturbosch.detekt:detekt-rules-empty:1.21.0-RC1
          +--- io.gitlab.arturbosch.detekt:detekt-rules-errorprone:1.21.0-RC1
          |    \--- io.gitlab.arturbosch.detekt:detekt-tooling:1.21.0-RC1 (*)
          +--- io.gitlab.arturbosch.detekt:detekt-rules-exceptions:1.21.0-RC1
          +--- io.gitlab.arturbosch.detekt:detekt-rules-naming:1.21.0-RC1
          +--- io.gitlab.arturbosch.detekt:detekt-rules-performance:1.21.0-RC1
          \--- io.gitlab.arturbosch.detekt:detekt-rules-style:1.21.0-RC1

detektPlugins - The detektPlugins libraries to be used for this project.
+--- io.gitlab.arturbosch.detekt:detekt-formatting:1.21.0-RC1
|    +--- com.pinterest.ktlint:ktlint-ruleset-standard:0.45.2
|    |    +--- com.pinterest.ktlint:ktlint-core:0.45.2
|    |    |    +--- org.ec4j.core:ec4j-core:0.3.0
|    |    |    \--- io.github.microutils:kotlin-logging-jvm:2.1.21
|    |    |         \--- org.slf4j:slf4j-api:1.7.32 -> 1.7.36
|    |    \--- io.github.microutils:kotlin-logging-jvm:2.1.21 (*)
|    +--- com.pinterest.ktlint:ktlint-core:0.45.2 (*)
|    +--- com.pinterest.ktlint:ktlint-ruleset-experimental:0.45.2
|    |    \--- com.pinterest.ktlint:ktlint-core:0.45.2 (*)
|    \--- org.slf4j:slf4j-nop:1.7.36
|         \--- org.slf4j:slf4j-api:1.7.36
\--- project :checks-detekt
     +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.7.21
     |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.7.21
     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.7.21
     |    |    \--- org.jetbrains:annotations:13.0
     |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.21
     |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.21 (*)
     +--- io.gitlab.arturbosch.detekt:detekt-api:1.21.0-RC1
     |    +--- io.gitlab.arturbosch.detekt:detekt-utils:1.21.0-RC1
     |    +--- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.6.21 -> 1.7.21
     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.7.21 (*)
     |    |    +--- org.jetbrains.kotlin:kotlin-script-runtime:1.7.21
     |    |    +--- org.jetbrains.kotlin:kotlin-reflect:1.7.21
     |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.7.21 (*)
     |    |    +--- org.jetbrains.kotlin:kotlin-daemon-embeddable:1.7.21
     |    |    +--- org.jetbrains.intellij.deps:trove4j:1.0.20200330
     |    |    \--- net.java.dev.jna:jna:5.6.0
     |    \--- io.gitlab.arturbosch.detekt:detekt-psi-utils:1.21.0-RC1
     |         \--- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.6.21 -> 1.7.21 (*)
     \--- org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.21 (*)

(*) - dependencies omitted (listed previously)

A web-based, searchable dependency report is available by adding the --scan option.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.6/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 1s
6 actionable tasks: 1 executed, 5 up-to-date
./gradlew dependencies  0.78s user 0.09s system 39% cpu 2.164 total
```

</details>

As a disclaimer, I do not have a lot of knowledge of the Android/Gradle build systems, so I could be missing something, but after testing this fork on our Bitrise project, I can confirm that the change seems to be working like I expect it to be.

In my project, this metadata directory is very small (only 18 kb) so I don't think it's an issue including this in the cache. The only issue I can think of is potential invalidation issues but I don't think that is an issue here. 

The main thinking behind this change is that if we're already caching the dependencies themselves, we might as well be caching the metadata to avoid the unnecessary network request and at the same time we make workflows a bit more resilient to network issues.

### Decisions

N/A
