### PR TITLE
Own gradle directory before trying to remove in e2e test

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -36,6 +36,7 @@ workflows:
         - content: |-
             set -ex
             ./gradlew -stop
+            sudo chown -R $USER:$GROUP ~/.gradle
             sudo rm -rf ./_tmp/.gradle
             ls -la ~/.gradle
             sudo rm -rf ~/.gradle
@@ -82,6 +83,7 @@ workflows:
         - content: |-
             set -ex
             ./gradlew -stop
+            sudo chown -R $USER:$GROUP ~/.gradle
             sudo rm -rf ~/.gradle
             sudo rm -rf ./_tmp/.gradle
     - path::./:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

This fixes e2e tests. The test was failing with a permission denied on the `~/.gradle` directory when trying to remove it.

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

* `chown` the `~/.gradle` directory before trying to remove it.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
