### PR TITLE
Add .konan dir to Cache for Kotlin multiplatform projects

### DIFF
--- a/step/step.go
+++ b/step/step.go
@@ -50,6 +50,10 @@ var paths = []string{
 
 	// JDKs downloaded by the toolchain support
 	"~/.gradle/jdks",
+
+	// Konan native compiler and dependencies
+	"~/.konan/kotlin-*"
+	"~/.konan/dependencies"
 }
 
 type Input struct {


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *PATCH* [version update](https://semver.org/)

### Context
Also cache the kotlin native compiler for Android projects that use KMP or android project that have a dependency on a KMP project.

### Changes
Added the `.konan/dependencies` folder and `.konan/kotlin-*` files which get downloaded by gradle when building kmp projects