### PR TITLE
feat: ACI-3054 Save artifact transforms and remove config cache

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -30,6 +30,7 @@ workflows:
         is_skippable: false
         inputs:
         - verbose: "true"
+        - save_transforms: "true"
     - script:
         title: Delete local Gradle caches
         inputs:

--- a/step.yml
+++ b/step.yml
@@ -52,3 +52,11 @@ inputs:
     title: Compression level
     summary: Zstd compression level to control speed / archive size. Set to 1 for fastest option. Valid values are between 1 and 19. Defaults to 3.
     is_required: false
+- save_transforms: "false"
+  opts:
+    title: Save transforms
+    summary: Save transformed classes and resources under `$HOME/.gradle/caches/**/transforms`
+    is_required: true
+    value_options:
+      - "true"
+      - "false"

--- a/step.yml
+++ b/step.yml
@@ -58,5 +58,5 @@ inputs:
     summary: Save transformed classes and resources under `$HOME/.gradle/caches/**/transforms`
     is_required: true
     value_options:
-      - "true"
-      - "false"
+    - "true"
+    - "false"

--- a/step/step.go
+++ b/step/step.go
@@ -54,6 +54,7 @@ var paths = []string{
 type Input struct {
 	Verbose          bool `env:"verbose,required"`
 	CompressionLevel int  `env:"compression_level,range[1..19]"`
+	SaveTransforms   bool `env:"save_transforms"`
 }
 
 type SaveCacheStep struct {
@@ -89,6 +90,13 @@ func (step SaveCacheStep) Run() error {
 		return fmt.Errorf("failed to parse inputs: %w", err)
 	}
 	stepconf.Print(input)
+
+	if input.SaveTransforms {
+		// Save artifact transforms
+		// The `**` segment matches the version-specific folder, such as `7.6`.
+		paths = append(paths, "~/.gradle/caches/**/transforms")
+	}
+
 	step.logger.Println()
 	step.logger.Printf("Cache key: %s", key)
 	step.logger.Printf("Cache paths:")

--- a/step/step.go
+++ b/step/step.go
@@ -45,8 +45,7 @@ var paths = []string{
 	// Cache of downloaded Gradle binary
 	"~/.gradle/wrapper",
 
-	// Configuration cache in project-level folder
-	".gradle/configuration-cache",
+	// Configuration cache is saved by separate step: save-gradle-configuration-cache
 
 	// JDKs downloaded by the toolchain support
 	"~/.gradle/jdks",


### PR DESCRIPTION
- Removing config cache from saved directories as it's superseded by the dedicated step
- Adding option to save transformed classes that might be needed for config cache

Example run
- Save https://app.bitrise.io/build/66d105d7-c6f1-4512-a00c-399c9e65ea57?tab=log
- Restore https://app.bitrise.io/build/9fdef01a-1696-43cc-8548-26f1f613ceb7?tab=log

Enabling this increases the cache archive size (default compression level) from ~720MB -> ~960MB