### PR TITLE
Add .konan cache paths for Kotlin Multiplatform projects

### DIFF
--- a/step/step.go
+++ b/step/step.go
@@ -49,6 +49,12 @@ var paths = []string{
 
 	// JDKs downloaded by the toolchain support
 	"~/.gradle/jdks",
+
+	// Kotlin Native compiler distributions for Kotlin Multiplatform projects
+	"~/.konan/kotlin-*",
+
+	// Kotlin Native dependencies (LLVM toolchain, sysroots) for Kotlin Multiplatform projects
+	"~/.konan/dependencies",
 }
 
 type Input struct {


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *MINOR* [version update](https://semver.org/) — additive new cache paths.

### Context

Continues #18 from @aegis123 — picking it up since it has been sitting for a while. Same idea, syntax fix + extra comments.

Cache the Kotlin Native compiler distribution and its dependencies for Kotlin Multiplatform / KMP projects. On a fresh agent, Kotlin Native downloads several GB into `~/.konan/` (LLVM toolchain, sysroots, the KN compiler itself) — caching this directory is a meaningful speedup for KMP builds.

### Changes

Adds two new paths to the cached set:

- `~/.konan/kotlin-*` — Kotlin Native compiler distributions (versioned)
- `~/.konan/dependencies` — downloaded native deps (LLVM, sysroots, etc.)

Paths are no-ops for non-KMP projects since the directories simply won't exist.

### Related PRs

- #18 (original, will be closed in favour of this)
- Companion PR for restore step to follow.