### PR TITLE
Fix e2e cleanup failing on noble-24.04 stack

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -33,7 +33,10 @@ workflows:
             sudo chown -R $USER:$GROUP ~/.gradle
             sudo rm -rf ./_tmp/.gradle
             ls -la ~/.gradle
-            sudo rm -rf ~/.gradle
+            # Skip ~/.gradle/init.d — populated by the Bitrise stack image and
+            # held open on the noble-24.04 docker stack, which causes
+            # `rm -rf ~/.gradle` to fail with "Device or resource busy".
+            sudo find ~/.gradle -mindepth 1 -maxdepth 1 ! -name init.d -exec rm -rf {} +
     - restore-cache:
         run_if: "true"
         is_skippable: false
@@ -76,7 +79,10 @@ workflows:
             set -ex
             ./gradlew -stop
             sudo chown -R $USER:$GROUP ~/.gradle
-            sudo rm -rf ~/.gradle
+            # Skip ~/.gradle/init.d — populated by the Bitrise stack image and
+            # held open on the noble-24.04 docker stack, which causes
+            # `rm -rf ~/.gradle` to fail with "Device or resource busy".
+            sudo find ~/.gradle -mindepth 1 -maxdepth 1 ! -name init.d -exec rm -rf {} +
             sudo rm -rf ./_tmp/.gradle
     - path::./:
         title: Execute step


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] \`step.yml\` and \`README.md\` is updated with the changes (if needed)

### Version

No version bump — e2e workflow change only, step is not affected.

### Context

CI is blocked on the \`ubuntu-noble-24.04-bitrise-2025-android\` matrix slot for #17 and #32 (and other PRs):

\`\`\`
+ sudo rm -rf /root/.gradle
rm: cannot remove '/root/.gradle/init.d': Device or resource busy
exit status 1
\`\`\`

The noble-24.04 docker image populates \`/root/.gradle/init.d\` with stack-provided init scripts and holds them open, so the cleanup blocks in \`e2e/bitrise.yml\` fail when they try to remove the whole \`~/.gradle\` directory. The older \`linux-docker-android-22.04\` image didn't do this, so the test workflow was fine there.

Confirmed the stack itself is healthy: PR #29 on \`bitrise-step-android-build-for-ui-testing\` ran on the same noble-24.04 stack today and passed — that workflow just doesn't try to wipe \`~/.gradle\`.

### Changes

Replace \`rm -rf ~/.gradle\` with a \`find\` that skips \`init.d\` in both cleanup blocks (\`test_full\` and \`test_empty\` workflows). The cleanup still removes everything Gradle generates between runs (\`caches\`, \`wrapper\`, \`jdks\`, etc.), which is what the tests actually depend on.

Sibling fix: bitrise-steplib/bitrise-step-restore-gradle-cache#<pending>