### PR TITLE
feat: ACI-5159 honor custom GRADLE_USER_HOME / KONAN_DATA_DIR when saving Gradle caches

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -62,6 +62,69 @@ workflows:
         - module: app
         - variant: debug
 
+  test_gradle_custom_gradle_user_home:
+    description: |
+      Same as test_gradle but with a non-default GRADLE_USER_HOME. Gradle writes its
+      caches under $GRADLE_USER_HOME, so the step must save/restore from there rather
+      than ~/.gradle.
+    envs:
+    - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-Android-Sample
+    - BRANCH: main
+    - GRADLE_USER_HOME: $HOME/custom-gradle-home
+    before_run:
+    - _setup
+    steps:
+    - change-workdir:
+        title: Switch working dir to _tmp
+        inputs:
+        - path: ./_tmp
+    - android-build:
+        inputs:
+        - module: app
+        - variant: debug
+    - path::./:
+        title: Execute step
+        run_if: "true"
+        is_skippable: false
+        inputs:
+        - verbose: "true"
+        - save_transforms: "true"
+    - script:
+        title: Delete custom GRADLE_USER_HOME caches
+        inputs:
+        - content: |-
+            set -ex
+            ./gradlew -stop
+            sudo chown -R $USER:$GROUP "$GRADLE_USER_HOME"
+            sudo rm -rf ./_tmp/.gradle
+            ls -la "$GRADLE_USER_HOME"
+            sudo find "$GRADLE_USER_HOME" -mindepth 1 -maxdepth 1 ! -name init.d -exec rm -rf {} +
+    - restore-cache:
+        run_if: "true"
+        is_skippable: false
+        inputs:
+        - key: "{{ .OS }}-{{ .Arch }}-gradle-cache-"
+        - verbose: "true"
+    - script:
+        title: Verify restored folder under GRADLE_USER_HOME
+        inputs:
+        - content: |-
+            set -ex
+            # Caches must be restored under the custom GRADLE_USER_HOME, not ~/.gradle.
+            if [ ! -d "$GRADLE_USER_HOME/caches" ]; then
+              echo "$GRADLE_USER_HOME/caches directory doesn't exist"
+              exit 1
+            fi
+            if [ ! -d "$GRADLE_USER_HOME/wrapper" ]; then
+              echo "$GRADLE_USER_HOME/wrapper directory doesn't exist"
+              exit 1
+            fi
+    - android-build:
+        title: Build app again
+        inputs:
+        - module: app
+        - variant: debug
+
   test_empty:
     description: |
       Tests the case when there is nothing to compress based on the cache paths. The step returns early in this case

--- a/step/step.go
+++ b/step/step.go
@@ -24,37 +24,63 @@ const (
 	key = `{{ .OS }}-{{ .Arch }}-gradle-cache-{{ checksum "**/*.gradle*" "**/gradle-wrapper.properties" "**/gradle.properties" "**/libs.versions.toml" }}`
 )
 
-// Cached paths
-var paths = []string{
+func gradleUserHome(envRepo env.Repository) string {
+	if v := strings.TrimSpace(envRepo.Get("GRADLE_USER_HOME")); v != "" {
+		return v
+	}
 
-	// Dependency JARs
-	"~/.gradle/caches/jars-*",
+	return "~/.gradle"
+}
 
-	// Dependency AARs
-	"~/.gradle/caches/modules-*/files-*",
-	"~/.gradle/caches/modules-*/metadata-*",
+func konanDataDir(envRepo env.Repository) string {
+	if v := strings.TrimSpace(envRepo.Get("KONAN_DATA_DIR")); v != "" {
+		return v
+	}
 
-	// Generated JARs for plugins and build scripts
-	// The `**` segment matches the version-specific folder, such as `7.6`.
-	"~/.gradle/caches/**/generated-gradle-jars/*.jar",
+	return "~/.konan"
+}
 
-	// Kotlin build script cache
-	// The `**` segment matches the version-specific folder, such as `7.6`.
-	"~/.gradle/caches/**/kotlin-dsl",
+func cachePaths(gradleHome, konanDir string, saveTransforms bool) []string {
+	paths := []string{
 
-	// Cache of downloaded Gradle binary
-	"~/.gradle/wrapper",
+		// Dependency JARs
+		gradleHome + "/caches/jars-*",
 
-	// Configuration cache is saved by separate step: save-gradle-configuration-cache
+		// Dependency AARs
+		gradleHome + "/caches/modules-*/files-*",
+		gradleHome + "/caches/modules-*/metadata-*",
 
-	// JDKs downloaded by the toolchain support
-	"~/.gradle/jdks",
+		// Generated JARs for plugins and build scripts
+		// The `**` segment matches the version-specific folder, such as `7.6`.
+		gradleHome + "/caches/**/generated-gradle-jars/*.jar",
 
-	// Kotlin Native compiler distributions for Kotlin Multiplatform projects
-	"~/.konan/kotlin-*",
+		// Kotlin build script cache
+		// The `**` segment matches the version-specific folder, such as `7.6`.
+		gradleHome + "/caches/**/kotlin-dsl",
 
-	// Kotlin Native dependencies (LLVM toolchain, sysroots) for Kotlin Multiplatform projects
-	"~/.konan/dependencies",
+		// Cache of downloaded Gradle binary
+		gradleHome + "/wrapper",
+
+		// Configuration cache is saved by separate step: save-gradle-configuration-cache
+
+		// JDKs downloaded by the toolchain support
+		gradleHome + "/jdks",
+
+		// Kotlin/Native, relocated by KONAN_DATA_DIR (not GRADLE_USER_HOME).
+		konanDir + "/kotlin-*",
+		konanDir + "/dependencies",
+	}
+
+	if saveTransforms {
+		// Save artifact transforms
+		// The `**` segment matches the version-specific folder, such as `7.6`.
+		paths = append(paths,
+			gradleHome+"/caches/**/transforms",
+			gradleHome+"/caches/transforms-*",
+		)
+	}
+
+	return paths
 }
 
 type Input struct {
@@ -97,12 +123,7 @@ func (step SaveCacheStep) Run() error {
 	}
 	stepconf.Print(input)
 
-	if input.SaveTransforms {
-		// Save artifact transforms
-		// The `**` segment matches the version-specific folder, such as `7.6`.
-		paths = append(paths, "~/.gradle/caches/**/transforms")
-		paths = append(paths, "~/.gradle/caches/transforms-*")
-	}
+	paths := cachePaths(gradleUserHome(step.envRepo), konanDataDir(step.envRepo), input.SaveTransforms)
 
 	step.logger.Println()
 	step.logger.Printf("Cache key: %s", key)


### PR DESCRIPTION
## ACI-5159

Follow-up to the CLI fix ([bitrise-build-cache-cli#400](https://github.com/bitrise-io/bitrise-build-cache-cli/pull/400)).

### Problem
The cached path list hardcoded `~/.gradle` (and `~/.konan`). With a non-default `GRADLE_USER_HOME` (e.g. `/g`), Gradle writes its caches under `$GRADLE_USER_HOME`, so the step matched nothing:

```
No match for path pattern: ~/.gradle/caches/jars-*
No match for path pattern: ~/.gradle/caches/modules-*/files-*
Cache path doesn't exist: ~/.gradle/wrapper
```

### Fix
- Root the Gradle cache paths at the effective `GRADLE_USER_HOME` (falling back to `~/.gradle`).
- Root the Kotlin/Native paths at `KONAN_DATA_DIR` (falling back to `~/.konan`). Kotlin/Native follows `KONAN_DATA_DIR` / `konan.data.dir`, **not** `GRADLE_USER_HOME`.

**Restore needs no change.** The go-steputils key-based cache is archive-driven on restore: the saver glob-expands + absolutizes the paths and records them in the archive; `RestoreCacheInput` has no `Paths` field, so the restorer extracts to those recorded absolute paths. A correct save fixes the whole round-trip.

### e2e
Adds `test_gradle_custom_gradle_user_home`: mirrors `test_gradle` but sets `GRADLE_USER_HOME=$HOME/custom-gradle-home` and asserts the caches are saved and restored under `$GRADLE_USER_HOME` (not `~/.gradle`).

### Not covered
`konan.data.dir` set via **gradle.properties** is not honored — these steps don't parse gradle.properties values (they only checksum them for the cache key). `KONAN_DATA_DIR` covers the env-var case; adding gradle.properties parsing (with Gradle's property precedence) would be a separate change.

### Note
Transient on rollout: a restore of an archive saved by the *old* step still lands in `~/.gradle`; self-heals on the first save with the new step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)