### PR TITLE
fix: ACI-5159 drop unsupported project_type_tags (java, kotlin-multiplatform)

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -20,8 +20,6 @@ project_type_tags:
 - cordova
 - flutter
 - ionic
-- java
-- kotlin-multiplatform
 - react-native
 type_tags:
 - utility


### PR DESCRIPTION
### Problem
The steplib publish of **save-gradle-cache 1.6.1** ([steplib PR #5009](https://github.com/bitrise-io/bitrise-steplib/pull/5009)) failed its `Validate` step:

```
- (3/5) Running: Ensure all type_tags and project_type_tags are supported
 > Error:
   - invalid project_type_tag: java
   - invalid project_type_tag: kotlin-multiplatform
```

`java` and `kotlin-multiplatform` are not in the steplib's supported `project_type_tags` set (severity: error), so no new version can be published. They were added in #32 (alongside the `.konan` cache paths); 1.6.0 is grandfathered in steplib but new versions are blocked.

### Fix
Remove the two unsupported tags. The remaining tags (`android`, `cordova`, `flutter`, `ionic`, `react-native`) all pass validation. Kotlin/Native (konan) and Java dependency caching is unaffected — `project_type_tags` are steplib discovery metadata only, not runtime behavior.

### Follow-up
After merge, re-release as **1.6.2** (1.6.1's tag is consumed and its steplib PR failed) to ship the `GRADLE_USER_HOME`/`KONAN_DATA_DIR` support that 1.6.1 was meant to deliver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)