### PR TITLE
[ACI-5187] Anchor Gradle cache key checksum to *.gradle/*.gradle.kts

### DIFF
--- a/step/step.go
+++ b/step/step.go
@@ -17,11 +17,11 @@ const (
 	// Cache key template
 	// OS + Arch: to guarantee that stack-specific content (absolute paths, binaries) are stored separately
 	// checksum values:
-	// - `**/*.gradle*`: Gradle build files in any submodule, including ones written in Kotlin (*.gradle.kts)
+	// - `**/*.gradle`, `**/*.gradle.kts`: Gradle build files (Groovy + Kotlin DSL); extensions anchored so generated `*.gradle.plugin` publish markers can't make the key non-deterministic
 	// - `**/gradle-wrapper.properties`: contains exact Gradle version
 	// - `**/gradle.properties`: contains Gradle config values
 	// - `**/libs.versions.toml`: version catalog file, contains dependencies and their versions
-	key = `{{ .OS }}-{{ .Arch }}-gradle-cache-{{ checksum "**/*.gradle*" "**/gradle-wrapper.properties" "**/gradle.properties" "**/libs.versions.toml" }}`
+	key = `{{ .OS }}-{{ .Arch }}-gradle-cache-{{ checksum "**/*.gradle" "**/*.gradle.kts" "**/gradle-wrapper.properties" "**/gradle.properties" "**/libs.versions.toml" }}`
 )
 
 func gradleUserHome(envRepo env.Repository) string {


### PR DESCRIPTION
[ACI-5187](https://bitrise.atlassian.net/browse/ACI-5187)

## Summary

The default Gradle cache **key** hashed `**/*.gradle*`, a glob that matches any filename merely *containing* `.gradle` — not just build scripts. In plugin-publish workflows this matches generated Maven **plugin marker** artifacts named `<plugin-id>.gradle.plugin` (e.g. `<id>.gradle.plugin-<ver>.pom` / `.module`) that publish tasks write into the workspace. They are absent at restore (fresh clone) but present at save, so the key differs between restore and save on the *same commit*, the save step can never skip, and it re-uploads the entire (multi-GB) archive on every build. This anchors the glob to `**/*.gradle` + `**/*.gradle.kts` so only real build scripts are hashed.

## Changes

- `step/step.go`: cache key checksum `**/*.gradle*` → `**/*.gradle` `**/*.gradle.kts`.

## Testing

- `go build ./...` — clean
- `gofmt -l step/` — clean
- `go vet ./step/` — clean
- Repo has no Go unit tests (`[no test files]`); the e2e workflow was not run in this environment.

## Notes for reviewers

- **Must be released in lockstep with the restore step** — both steps hardcode this key template and must compute the same key for save-skipping to work. Sibling PR: https://github.com/bitrise-steplib/bitrise-step-restore-gradle-cache/pull/23
- **No fleet-wide cache invalidation.** Per `go-steputils/v2 cache/keytemplate/checksum.go`, matched files across all glob args are collected, globally sorted, and hashed in order (no dedup). `build.gradle` matches only `*.gradle`; `build.gradle.kts` / `settings.gradle.kts` match only `*.gradle.kts`; no file matches both. For a normal project the two patterns partition the exact same set the old glob matched → identical sorted list → identical hash → identical key. Only projects that were (incorrectly) hashing generated `.gradle`-containing artifacts get a changed — corrected — key (one-time miss, then stable).
- **Evidence.** Fanatics `cd-deploy-plugin` (publishes via `publishAllPublicationsToLocalRepository`): restore key `…0db89f7c` → save key `…e1f6b4a0` on the same commit → "Can't skip uploading the cache" → ~9 GB re-uploaded every deploy. Our own `gradle-plugins` e2e build (same step/key, comparable multi-module project, builds but doesn't publish): restore key == save key → "Cache save can be skipped".


[ACI-5187]: https://bitrise.atlassian.net/browse/ACI-5187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ